### PR TITLE
Do svn checkout externally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+completesearch/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,20 +11,15 @@ RUN apt-get update && apt-get -y upgrade && \
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
     apt-get install -y nodejs
 
-# Build arguments
-ARG SVN_USERNAME
-ARG SVN_PASSWORD
 
 ENV LANG en_US.UTF-8
 ENV TERM xterm
 
+COPY completesearch /usr/src/completesearch/
 WORKDIR /usr/src/completesearch
 
-# Download CompleteSearch codebase
-RUN svn checkout https://ad-svn.informatik.uni-freiburg.de/completesearch/codebase --username $SVN_USERNAME --password $SVN_PASSWORD --non-interactive --trust-server-cert --revision 1715 .
-
 # Fix some bugs in the source code (temporary solution)
-ADD fixes/* server/
+COPY fixes/* server/
 
 # Build the codebase
 RUN make build-all
@@ -32,7 +27,7 @@ RUN make build-all
 WORKDIR /usr/src/app
 
 # Download web app
-RUN git clone https://github.com/anatskiy/CompleteSearch.git .
+RUN git clone https://github.com/niklas88/CompleteSearch.git .
 
 # Install backend dependencies
 RUN pip3 install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -13,34 +13,31 @@ Install Docker.
 ### Step 1
 
 Clone this repository:
-```
-git clone https://github.com/anatskiy/docker-completesearch.git
-cd docker-completesearch
-```
+
+    git clone https://github.com/anatskiy/docker-completesearch.git
+    cd docker-completesearch
+
+Checkout the Completesearch repository into a subfolder called `completesearch`
+
+    svn checkout https://ad-svn.informatik.uni-freiburg.de/completesearch/codebase --username <username> --revision 1715 completesearch
+
+Where `<username>` is the one for the CompleteSearch svn repository. [More
+information](http://ad-wiki.informatik.uni-freiburg.de/completesearch).
 
 Build the image:
-```
-docker build \
-    -t completesearch \
-    --build-arg SVN_USERNAME="username" \
-    --build-arg SVN_PASSWORD="password" \
-    .
-```
-Where `SVN_USERNAME` and `SVN_PASSWORD` are your credentials for the CompleteSearch svn repository. [More information](http://ad-wiki.informatik.uni-freiburg.de/completesearch).
 
-**Note:** You need to escape username and password with double quotes "".
+    docker build -t completesearch .
 
 ### Step 2
 
 Run the container:
-```
-docker run -d \
-    --name completesearch \
-    -p 8000:8000 \
-    -p 8888:8888 \
-    completesearch \
-    python3 manage.py runserver -h 0.0.0.0 -p 8000
-```
+
+    docker run -d \
+        --name completesearch \
+        -p 8000:8000 \
+        -p 8888:8888 \
+        completesearch \
+        python3 manage.py runserver -h 0.0.0.0 -p 8000
 
 ---
 


### PR DESCRIPTION
Instead of doing the checkout in docker just checkout to a local folder
and COPY that into the build container. This way the SVN credentials
don't end up in the shell history or inside the container (through credential caching).

That said I think I'd prefer to have the `Dockerfile` in the main repository.